### PR TITLE
Plugin2 compatibility change: stop using :no_dsl

### DIFF
--- a/lib/Dancer2/Plugin/ElasticSearch.pm
+++ b/lib/Dancer2/Plugin/ElasticSearch.pm
@@ -11,7 +11,7 @@ use utf8;
 
 use Search::Elasticsearch;
 use Try::Tiny;
-use Dancer2::Plugin qw/:no_dsl/;
+use Dancer2::Plugin;
 
 our $handles = {};
 


### PR DESCRIPTION
Starting with Dancer2 (to be released) plugin2 compatibility release the `:no_dsl pragma` option for Dancer2::Plugin is no longer supported.
